### PR TITLE
Compile under 5.22.0, too.

### DIFF
--- a/Coro/schmorp.h
+++ b/Coro/schmorp.h
@@ -26,6 +26,11 @@
        && (PERL_VERSION > (b)					\
            || (PERL_VERSION == (b) && PERL_SUBVERSION >= (c)))))
 
+#if PERL_VERSION_ATLEAST(5,22,0) && !PERL_VERSION_ATLEAST(5,22,1)
+# undef PadlistNAMES
+# define PadlistNAMES(pl)      *((PADNAMELIST **)PadlistARRAY(pl))
+#endif
+
 #ifndef PERL_MAGIC_ext
 # define PERL_MAGIC_ext '~'
 #endif


### PR DESCRIPTION
Since 5.22.0 went out with this problem, add in a patch for that as well, otherwise won't be able to use Coro until 5.22.1